### PR TITLE
Replies and retweets

### DIFF
--- a/BotCode.gs
+++ b/BotCode.gs
@@ -544,7 +544,7 @@ function curfew() {
       return true;
     }
   } else {
-    if (hour >= quietBegin | hour < quietEnd) {
+    if (hour >= quietBegin || hour < quietEnd) {
       Logger.log("Quiet hours");
       return true;
     }

--- a/BotCode.gs
+++ b/BotCode.gs
@@ -1,6 +1,6 @@
 /* 
 
-   A Spreadsheet-powered Twitter Bot Engine, version 0.6.0, August 2019
+   A Spreadsheet-powered Twitter Bot Engine, version 0.6.5, May 2020
    
    by Zach Whalen (@zachwhalen, zachwhalen.net)
    

--- a/BotCode.gs
+++ b/BotCode.gs
@@ -442,7 +442,7 @@ function generateSingleTweet() {
       tweet.length > properties.min &&
       !wordFilter(tweet) &&
       !curfew() &&
-      tempID[i] !== 'Schedule') {
+      (typeof tempID === 'undefined' || tempID[i] !== 'Schedule')) {
       if (properties.removeMentions == 'yes') {
         tweet = tweet.replace(/@[a-zA-Z0-9_]+/g, '');
       }

--- a/BotCode.gs
+++ b/BotCode.gs
@@ -469,6 +469,12 @@ function generateSingleTweet() {
     tempID = tempArray.map(function(value,index) { return value[1]; });
     retweetIDs = tempArray.map(function(value,index) { return value[2]; });
     replyIDs = tempArray.map(function(value,index) { return value[3]; });
+    if (tempID[0] === 'Schedule') {
+      doLog("Scheduled Tweet: There is nothing to Tweet now","","Nothing");
+      Logger.log("Scheduled Tweet: Nothing to tweet in this time block");
+      //Nothing happened so it is safe to move the lastRunTime forward.
+      scriptProperties.setProperty('lastRunTime', now.toJSON());
+    }
   } else {
     temp = getTweets(1, false);
   }

--- a/BotCode.gs
+++ b/BotCode.gs
@@ -228,7 +228,7 @@ function setTiming(nextPostTime) {
   var timing = properties.timing;
 
   if (properties.timingReset == "true") {
-    doLog("Resetting Scheduled Posting.","","Reset Timing");
+    doLog("","Resetting Scheduled Posting.","Reset Timing");
     scriptProperties.setProperty('timingReset', "false");
   }
 
@@ -279,21 +279,21 @@ function setTiming(nextPostTime) {
           .everyHours(temp_timing)
           .create();
       Logger.log("Scheduled Posting set to every " + temp_timing + (temp_timing > 1?" Hours.":" Hour."));
-      doLog("Scheduled Posting set to every " + temp_timing + (temp_timing > 1?" Hours.":" Hour."),"","Set Timing");
+      doLog("","Scheduled Posting set to every " + temp_timing + (temp_timing > 1?" Hours.":" Hour."),"Set Timing");
     } else if (timing > 0) {
       trigger = ScriptApp.newTrigger("generateSingleTweet")
           .timeBased()
           .everyMinutes(timing)
           .create();
       Logger.log("Scheduled Posting set to every " + timing + (timing > 1?" Minutes.":" Minute."));
-      doLog("Scheduled Posting set to every " + timing + (timing > 1?" Minutes.":" Minute."),"","Set Timing");
+      doLog("","Scheduled Posting set to every " + timing + (timing > 1?" Minutes.":" Minute."),"Set Timing");
     } else {
       trigger = ScriptApp.newTrigger("generateSingleTweet")
           .timeBased()
           .everyHours(1)
           .create();
       Logger.log("I couldn't find an interval to set so I assumed 1 hour.");
-      doLog("Scheduled Posting set to every 1 Hour. (Default)","","Set Timing");
+      doLog("","Scheduled Posting set to every 1 Hour. (Default)","Set Timing");
     }
     if (properties.isScheduledPosting != "true") {
       scriptProperties.setProperty('isScheduledPosting', true);
@@ -320,7 +320,7 @@ function clearTiming(trigger) {
   }
   if (typeof trigger === 'undefined') {
     Logger.log("Scheduled Posting turned off.");
-    doLog("Scheduled Posting turned off.","","Set Timing");
+    doLog("","Scheduled Posting turned off.","Set Timing");
     scriptProperties.setProperty('isScheduledPosting', false);
   }
 }
@@ -465,7 +465,7 @@ function generateSingleTweet() {
   if (properties.constructor == "scheduled") {
     var tempArray = getTweets(1, false); //1 tweet per block of time
     if (typeof tempArray == 'undefined' || tempArray.length < 1) {
-      doLog("Scheduled Tweet: There is nothing to Tweet now","","Nothing");
+      doLog("","Scheduled Tweet: There is nothing to Tweet now","Nothing");
       Logger.log("Scheduled Tweet: Nothing to tweet in this time block");
       //Nothing happened so it is safe to move the lastRunTime forward.
       scriptProperties.setProperty('lastRunTime', now.toJSON());
@@ -476,7 +476,7 @@ function generateSingleTweet() {
     retweetIDs = tempArray.map(function(value,index) { return value[2]; });
     replyIDs = tempArray.map(function(value,index) { return value[3]; });
     if (tempID[0] === 'Schedule') {
-      doLog("Scheduled Tweet: There is nothing to Tweet now","","Nothing");
+      doLog("","Scheduled Tweet: There is nothing to Tweet now","Nothing");
       Logger.log("Scheduled Tweet: Nothing to tweet in this time block");
       //Nothing happened so it is safe to move the lastRunTime forward.
       scriptProperties.setProperty('lastRunTime', now.toJSON());
@@ -533,7 +533,7 @@ function generateSingleTweet() {
       } else if (wordFilter(tweet)) {
         doLog("Tweet uses banned words", tweet, 'Error');
       } else {
-        doLog("Tweet to Short or nonexistent", '', 'Error');
+        doLog("Tweet to Short or nonexistent", tweet, 'Error');
       }
     }
   }

--- a/BotCode.gs
+++ b/BotCode.gs
@@ -258,6 +258,11 @@ function setTiming(nextPostTime) {
       } else {
         timing = 1;
       }
+      if (timing > 1) {
+        //More than 1 minute until next tweet so it is safe to move the lastRunTime forward.
+          var now = new Date();
+          scriptProperties.setProperty('lastRunTime', now.toJSON());
+      }
     } else {
       timing = 1; //Since we have no idea when the next scheduled post should be assume it needs to be immediately.
     }
@@ -321,11 +326,13 @@ function clearTiming(trigger) {
 }
 
 function resetTiming() {
-  var p = PropertiesService.getScriptProperties().getProperties();
-  var sanityFactor = (9)*60000;                     //Only do anything if no runs in this long
+  var scriptProperties = PropertiesService.getScriptProperties();
+  var p = scriptProperties.getProperties();
+  var sanityFactor = 9;                     //Only do anything if no runs in this many minutes
 
   var now = new Date();
-  var lastRunFudged = new Date(p.lastRunTime + sanityFactor);
+  var lastRunFudged = new Date(p.lastRunTime);
+  lastRunFudged.setMinutes(lastRunFudged.getMinutes() + sanityFactor)
 
   if (now > lastRunFudged) {
     Logger.log("Resetting Scheduled Posting.");

--- a/BotCode.gs
+++ b/BotCode.gs
@@ -531,15 +531,15 @@ function curfew() {
   var time = new Date();
   var hour = time.getHours();
 
-  var quietBegin = properties.quietStart;
-  var quietEnd = properties.quietEnd;
+  var quietBegin = parseFloat(properties.quietStart);
+  var quietEnd = parseFloat(properties.quietEnd);
 
   if (quietBegin == quietEnd) {
     return false;
   }
 
   if (quietEnd > quietBegin) {
-    if (hour >= quietBegin & hour < quietEnd) {
+    if (hour >= quietBegin && hour < quietEnd) {
       Logger.log("Quiet hours");
       return true;
     }
@@ -549,6 +549,9 @@ function curfew() {
       return true;
     }
   }
+
+  return false;
+}
 
   return false;
 }

--- a/BotCode.gs
+++ b/BotCode.gs
@@ -495,7 +495,8 @@ function fixedEncodeURIComponent(str) {
 
 function authorizationRevoke() {
   var scriptProperties = PropertiesService.getScriptProperties();
-  scriptProperties.deleteProperty('oauth1.twitter');
+  var service = getTwitterService();
+  service.reset();
   msgPopUp('<p>Your Twitter authorization credentials have been deleted. You\'ll need to re-run "Send a Test Tweet" to reauthorize before you can start posting again.');
 }
 

--- a/BotCode.gs
+++ b/BotCode.gs
@@ -328,22 +328,28 @@ function clearTiming(trigger) {
 function resetTiming() {
   var scriptProperties = PropertiesService.getScriptProperties();
   var p = scriptProperties.getProperties();
-  var sanityFactor = 9;                     //Only do anything if no runs in this many minutes
+  if (ScriptApp.getProjectTriggers().length < 1   //No active timing triggers (Note: adding triggers to this project will break this assumption.)
+      || p.timing != 1) {                         //Or current timing is not already the minimum.
 
-  var now = new Date();
-  var lastRunFudged = new Date(p.lastRunTime);
-  lastRunFudged.setMinutes(lastRunFudged.getMinutes() + sanityFactor)
+    var sanityFactor = 9;                     //Only do anything if no runs in this many minutes
 
-  if (now > lastRunFudged) {
-    Logger.log("Resetting Scheduled Posting.");
-    scriptProperties.setProperty('timingReset', "true");
-    trigger = ScriptApp.newTrigger("setTiming")
-          .timeBased()
-          .everyMinutes(1)
-          .create();
-      Logger.log("Resetting Scheduled Posting to every 1 Minute. (Note: setTiming should erase this trigger.)");
+    var now = new Date();
+    var lastRunFudged = new Date(p.lastRunTime);
+    lastRunFudged.setMinutes(lastRunFudged.getMinutes() + sanityFactor)
+
+    if (now > lastRunFudged) {
+      Logger.log("Resetting Scheduled Posting.");
+      scriptProperties.setProperty('timingReset', "true");
+      trigger = ScriptApp.newTrigger("setTiming")
+            .timeBased()
+            .everyMinutes(1)
+            .create();
+        Logger.log("Resetting Scheduled Posting to every 1 Minute. (Note: setTiming should erase this trigger.)");
+    } else {
+      Logger.log("Not Resetting Scheduled Posting Due to Recent Run.");
+    }
   } else {
-    Logger.log("Not Resetting Scheduled Posting Due to Recent Run.");
+    Logger.log("Not Resetting Scheduled Posting Due to no need.");
   }
 }
 

--- a/BotCode.gs
+++ b/BotCode.gs
@@ -70,7 +70,8 @@ function updateSettings() {
     setProperty('ban', ss[8].toString()).
     setProperty('removeHashes', ss[9].toString()).
     setProperty('removeMentions', ss[10].toString()).
-    setProperty('everyFail', ss[11].toString());
+    setProperty('everyFail', ss[11].toString().
+    setProperty('timingReset', false));
 
   var quietStart = SpreadsheetApp.getActiveSpreadsheet().getSheetByName("Settings").getRange("b8").getValue().getHours();
   var quietStop = SpreadsheetApp.getActiveSpreadsheet().getSheetByName("Settings").getRange("b9").getValue().getHours();
@@ -225,6 +226,11 @@ function setTiming(nextPostTime) {
   var properties = PropertiesService.getScriptProperties().getProperties();
   var scriptProperties = PropertiesService.getScriptProperties();
   var timing = properties.timing;
+
+  if (properties.timingReset) {
+    doLog("Resetting Scheduled Posting.","","Set Timing");
+    scriptProperties.setProperty('timingReset', false);
+  }
 
   if (properties.isAutoTiming == "true") {            //We are supposed to self adjust the timing schedule.
     if (nextPostTime) {                               //We know when the next run needs to be.

--- a/BotCode.gs
+++ b/BotCode.gs
@@ -674,8 +674,13 @@ function doTweet(tweet, tweetID, retweetID, replyID) {
     if (properties.constructor === 'every' && properties.everyFail === 'skip') {
       everyRotate();
     }
-    if (properties.constructor === 'scheduled' && properties.everyFail === 'skip') {
-      logScheduledTweet(tweetID, "Error", response);
+    if (properties.constructor === 'scheduled') {
+      if (properties.everyFail === 'skip') {
+        logScheduledTweet(tweetID, "Error", response);
+      } else {
+        //Something went wrong so be sure to try again as soon as possible.
+        setTiming();
+      }
     }
     if (properties.constructor === 'scheduled' && e.toString().includes("Status is a duplicate")) {
       logScheduledTweet(tweetID, "Duplicate (Race Condition?)", response);

--- a/BotCode.gs
+++ b/BotCode.gs
@@ -309,6 +309,7 @@ function setTiming(nextPostTime) {
 } 
 
 function clearTiming(trigger) {
+  //Note: If adding some additional whitelisted trigger here that never gets deleted, make sure to also update resetTiming() to account for it.
   var scriptProperties = PropertiesService.getScriptProperties();
   // clear any existing triggers
   var triggers = ScriptApp.getProjectTriggers();
@@ -338,13 +339,12 @@ function resetTiming() {
     lastRunFudged.setMinutes(lastRunFudged.getMinutes() + sanityFactor)
 
     if (now > lastRunFudged) {
-      Logger.log("Resetting Scheduled Posting.");
+      Logger.log("Clearing existing triggers.");
+      clearTiming();
+
+      Logger.log("Resetting Scheduled Posting to every 1 Minute.");
       scriptProperties.setProperty('timingReset', "true");
-      trigger = ScriptApp.newTrigger("setTiming")
-            .timeBased()
-            .everyMinutes(1)
-            .create();
-        Logger.log("Resetting Scheduled Posting to every 1 Minute. (Note: setTiming should erase this trigger.)");
+      setTiming();
     } else {
       Logger.log("Not Resetting Scheduled Posting Due to Recent Run.");
     }

--- a/BotCode.gs
+++ b/BotCode.gs
@@ -129,7 +129,7 @@ function logScheduledTweet(rowID, success, response) {
   if (success == "true") {
     var d = new Date();
     var display = Utilities.formatDate(d, SpreadsheetApp.getActive().getSpreadsheetTimeZone(), "yyyy-MM-dd hh:mm a");
-    scheduledSheet.getRange("b" + rowID + ":b" + rowID).setValue(response.id);
+    scheduledSheet.getRange("b" + rowID + ":b" + rowID).setValue(response.data.id);
   } else {
     display = success;
   }
@@ -670,11 +670,11 @@ function doTweet(tweet, tweetID, retweetID, replyID) {
       Logger.log(result.getContentText());
       var response = JSON.parse(result.getContentText());
 
-      if (response.id && properties.constructor === 'every') {
+      if (response.data.id && properties.constructor === 'every') {
         everyRotate();
       }
 
-      if (response.id && properties.constructor === 'scheduled') {
+      if (response.data.id && properties.constructor === 'scheduled') {
         logScheduledTweet(tweetID, "true", response);
       }
 

--- a/BotCode.gs
+++ b/BotCode.gs
@@ -659,12 +659,6 @@ function wordFilter(text) {
 
   var properties = PropertiesService.getScriptProperties().getProperties();
 
-  if (properties.ban.length > 1) {
-    var more = properties.ban.split(",");
-  }
-
-
-
   var badList = [
     "beeyotch", "biatch", "bitch", "chinaman", "chinamen", "chink", "cuck", "crip", "cunt", "dago", "daygo", "dego", "dick", "douchebag", "dyke", "fag", "fatass", "fatso", "gash", "gimp", "golliwog", "gook", "gyp", "halfbreed", "half-breed", "homo", "hooker", "jap", "kike", "kraut", "lame", "lardass", "lesbo", "negro", "nigga", "nigger", "paki", "pickaninny", "pussy", "raghead", "retard", "shemale", "skank", "slut", "spade", "spic", "spook", "tard", "tits", "titt", "trannies", "tranny", "twat", "wetback", "whore", "wop"
   ];
@@ -672,7 +666,10 @@ function wordFilter(text) {
   var banned = new Array();
 
   if (properties.ban.length > 1) {
-    var banned = badList.concat(properties.ban.split(","));
+    //If properties.ban is OFF then return empty array. Thus turning off this word filter.
+    if (properties.ban !== "OFF") {
+      var banned = badList.concat(properties.ban.split(","));      
+    }
   } else {
     var banned = badList;
   }

--- a/BotCode.gs
+++ b/BotCode.gs
@@ -314,6 +314,25 @@ function clearTiming(trigger) {
   }
 }
 
+function resetTiming() {
+  var p = PropertiesService.getScriptProperties().getProperties();
+  var sanityFactor = (9)*60000;                     //Only do anything if no runs in this long
+
+  var now = new Date();
+  var lastRunFudged = new Date(p.lastRunTime + sanityFactor);
+
+  if (now > lastRunFudged) {
+    Logger.log("Resetting Scheduled Posting.");
+    trigger = ScriptApp.newTrigger("setTiming")
+          .timeBased()
+          .everyMinutes(1)
+          .create();
+      Logger.log("Resetting Scheduled Posting to every 1 Minute. (Note: setTiming should erase this trigger.)");
+  } else {
+    Logger.log("Not Resetting Scheduled Posting Due to Recent Run.");
+  }
+}
+
 /*
 
   ADD THE "BOT" MENU

--- a/BotCode.gs
+++ b/BotCode.gs
@@ -653,11 +653,7 @@ function doTweet(tweet, tweetID, retweetID, replyID) {
         var payload = JSON.stringify({ text: tweet, reply:{in_reply_to_tweet_id: replyID}});
       }
     } else {
-      if (tweet.length == 0) {
-        var payload = JSON.stringify({tweet_id: retweetID });
-      } else {
-        var payload = JSON.stringify({ text: tweet, quote_tweet_id: retweetID });
-      }
+      var payload = JSON.stringify({ text: tweet, quote_tweet_id: retweetID });
     }
   
     var parameters = {
@@ -670,11 +666,7 @@ function doTweet(tweet, tweetID, retweetID, replyID) {
     };
 
     try {
-      if (tweet.length == 0 && typeof retweetID !== 'undefined' ) {
-        var result = UrlFetchApp.fetch('https://api.twitter.com/2/users/:id/retweets', parameters);
-      } else {
-        var result = UrlFetchApp.fetch('https://api.twitter.com/2/tweets', parameters);
-      }
+      var result = UrlFetchApp.fetch('https://api.twitter.com/2/tweets', parameters);
       Logger.log(result.getContentText());
       var response = JSON.parse(result.getContentText());
 

--- a/BotCode.gs
+++ b/BotCode.gs
@@ -70,8 +70,8 @@ function updateSettings() {
     setProperty('ban', ss[8].toString()).
     setProperty('removeHashes', ss[9].toString()).
     setProperty('removeMentions', ss[10].toString()).
-    setProperty('everyFail', ss[11].toString().
-    setProperty('timingReset', "false"));
+    setProperty('everyFail', ss[11].toString()).
+    setProperty('timingReset', "false");
 
   var quietStart = SpreadsheetApp.getActiveSpreadsheet().getSheetByName("Settings").getRange("b8").getValue().getHours();
   var quietStop = SpreadsheetApp.getActiveSpreadsheet().getSheetByName("Settings").getRange("b9").getValue().getHours();

--- a/BotCode.gs
+++ b/BotCode.gs
@@ -228,7 +228,7 @@ function setTiming(nextPostTime) {
   var timing = properties.timing;
 
   if (properties.timingReset) {
-    doLog("Resetting Scheduled Posting.","","Set Timing");
+    doLog("Resetting Scheduled Posting.","","Reset Timing");
     scriptProperties.setProperty('timingReset', false);
   }
 

--- a/BotCode.gs
+++ b/BotCode.gs
@@ -553,9 +553,6 @@ function curfew() {
   return false;
 }
 
-  return false;
-}
-
 function getMediaIds(tweet) {
 
   //var tweet = 'Testing http://i.imgur.com/AsghXmB.png http://i.imgur.com/Di9t0XB.jpg';

--- a/BotCode.gs
+++ b/BotCode.gs
@@ -118,12 +118,12 @@ function everyRotate() {
 function logScheduledTweet(rowID, success, response) {
   var display = "";
   var scheduledSheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName('scheduled');
-  if (success) {
+  if (success == "true") {
     var d = new Date();
     var display = Utilities.formatDate(d, SpreadsheetApp.getActive().getSpreadsheetTimeZone(), "yyyy-MM-dd hh:mm a");
     scheduledSheet.getRange("b" + rowID + ":b" + rowID).setValue(response.id_str);
   } else {
-    display = "Error";
+    display = success;
   }
   scheduledSheet.getRange("c" + rowID + ":c" + rowID).setValue(display);
 }
@@ -655,7 +655,7 @@ function doTweet(tweet, tweetID, retweetID, replyID) {
     }
 
     if (response.created_at && properties.constructor === 'scheduled') {
-      logScheduledTweet(tweetID, true, response);
+      logScheduledTweet(tweetID, "true", response);
     }
 
     doLog(response, tweet, 'Success');
@@ -668,7 +668,10 @@ function doTweet(tweet, tweetID, retweetID, replyID) {
       everyRotate();
     }
     if (properties.constructor === 'scheduled' && properties.everyFail === 'skip') {
-      logScheduledTweet(tweetID, false, response);
+      logScheduledTweet(tweetID, "Error", response);
+    }
+    if (properties.constructor === 'scheduled' && e.toString().includes("Status is a duplicate")) {
+      logScheduledTweet(tweetID, "Duplicate (Race Condition?)", response);
     }
   }
 

--- a/BotCode.gs
+++ b/BotCode.gs
@@ -115,16 +115,17 @@ function everyRotate() {
 
 }
 
-function logScheduledTweet(rowID, success) {
+function logScheduledTweet(rowID, success, response) {
   var display = "";
+  var scheduledSheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName('scheduled');
   if (success) {
     var d = new Date();
     var display = Utilities.formatDate(d, SpreadsheetApp.getActive().getSpreadsheetTimeZone(), "yyyy-MM-dd hh:mm a");
+    scheduledSheet.getRange("b" + rowID + ":b" + rowID).setValue(response.id_str);
   } else {
     display = "Error";
   }
-  var scheduledSheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName('scheduled');
-  scheduledSheet.getRange("a" + rowID + ":a" + rowID).setValue(display);
+  scheduledSheet.getRange("c" + rowID + ":c" + rowID).setValue(display);
 }
 
 function getTweets(count, preview) {
@@ -611,7 +612,7 @@ function doTweet(tweet, tweetID) {
     }
 
     if (response.created_at && properties.constructor === 'scheduled') {
-      logScheduledTweet(tweetID, true);
+      logScheduledTweet(tweetID, true, response);
     }
 
     doLog(response, tweet, 'Success');
@@ -624,7 +625,7 @@ function doTweet(tweet, tweetID) {
       everyRotate();
     }
     if (properties.constructor === 'scheduled' && properties.everyFail === 'skip') {
-      logScheduledTweet(tweetID, false);
+      logScheduledTweet(tweetID, false, response);
     }
   }
 

--- a/BotCode.gs
+++ b/BotCode.gs
@@ -71,7 +71,7 @@ function updateSettings() {
     setProperty('removeHashes', ss[9].toString()).
     setProperty('removeMentions', ss[10].toString()).
     setProperty('everyFail', ss[11].toString().
-    setProperty('timingReset', false));
+    setProperty('timingReset', "false"));
 
   var quietStart = SpreadsheetApp.getActiveSpreadsheet().getSheetByName("Settings").getRange("b8").getValue().getHours();
   var quietStop = SpreadsheetApp.getActiveSpreadsheet().getSheetByName("Settings").getRange("b9").getValue().getHours();
@@ -227,9 +227,9 @@ function setTiming(nextPostTime) {
   var scriptProperties = PropertiesService.getScriptProperties();
   var timing = properties.timing;
 
-  if (properties.timingReset) {
+  if (properties.timingReset == "true") {
     doLog("Resetting Scheduled Posting.","","Reset Timing");
-    scriptProperties.setProperty('timingReset', false);
+    scriptProperties.setProperty('timingReset', "false");
   }
 
   if (properties.isAutoTiming == "true") {            //We are supposed to self adjust the timing schedule.
@@ -329,6 +329,7 @@ function resetTiming() {
 
   if (now > lastRunFudged) {
     Logger.log("Resetting Scheduled Posting.");
+    scriptProperties.setProperty('timingReset', "true");
     trigger = ScriptApp.newTrigger("setTiming")
           .timeBased()
           .everyMinutes(1)

--- a/Constructors.gs
+++ b/Constructors.gs
@@ -241,17 +241,17 @@ function getScheduledText(count, preview) {
 
   //Wipe out wrong "Actual Tweet Time"
   for (i = 0; i < lastRow; i++) {
-    scheduledData[i].push(i + 4);
+    scheduledData[i].push(i + 4); //Row ID
     if (scheduledData[i][0] != "" &&
         (scheduledData[i][1] > afterNow             //"Desired Tweet Time" is in the future
         || scheduledData[i][0] > now)               //"Actual Tweet Time" is in the future
     ) {
       scheduledData[i][0] = "";
-      scheduledSheet.getRange("c" + (i + 4)).setValue("");
+      scheduledSheet.getRange("b" + scheduledData[i][3]+":c" + scheduledData[i][3]).setValues([["",""]]);
     }
     if (scheduledData[i][0] == "next-->") {         //Erase Next Pointer as it will be reset later
       scheduledData[i][0] = "";
-      scheduledSheet.getRange("c" + scheduledData[i][3]).setValue("");
+      scheduledSheet.getRange("b" + scheduledData[i][3]+":c" + scheduledData[i][3]).setValues([["",""]]);
     }
     if (scheduledData[i][1] < beforeNow             //Erase tweets that are in the past
         || scheduledData[i][0] > 0                  //Erase tweets that are already sent

--- a/Constructors.gs
+++ b/Constructors.gs
@@ -226,7 +226,7 @@ function getScheduledText(count, preview) {
   }
 
   var scheduledSheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName('scheduled');
-  var scheduledData = scheduledSheet.getRange("a" + 4 + ":c" + scheduledSheet.getLastRow()).getValues();
+  var scheduledData = scheduledSheet.getRange("c" + 4 + ":e" + scheduledSheet.getLastRow()).getValues();
   var lastRow = scheduledData.length;
   var afterFudgeFactor;
   if (p.isAutoTiming) {
@@ -247,11 +247,11 @@ function getScheduledText(count, preview) {
         || scheduledData[i][0] > now)               //"Actual Tweet Time" is in the future
     ) {
       scheduledData[i][0] = "";
-      scheduledSheet.getRange("a" + (i + 4)).setValue("");
+      scheduledSheet.getRange("c" + (i + 4)).setValue("");
     }
     if (scheduledData[i][0] == "next-->") {         //Erase Next Pointer as it will be reset later
       scheduledData[i][0] = "";
-      scheduledSheet.getRange("a" + scheduledData[i][3]).setValue("");
+      scheduledSheet.getRange("c" + scheduledData[i][3]).setValue("");
     }
     if (scheduledData[i][1] < beforeNow             //Erase tweets that are in the past
         || scheduledData[i][0] > 0                  //Erase tweets that are already sent
@@ -274,14 +274,14 @@ function getScheduledText(count, preview) {
         if (preview) {
           tweets.push(scheduledData[i][2]);                         //Preview gets the tweets only. (No row number)
           if (!foundPreview) {                                      //Previewing so first result is also next to be tweeted.
-            scheduledSheet.getRange("a" + scheduledData[i][3]).setValue("next-->");
+            scheduledSheet.getRange("c" + scheduledData[i][3]).setValue("next-->");
             foundPreview = true;
           }
         } else if (scheduledData[i][1] < afterNow) {                //Tweet is not to far in the future
           tweets.push([scheduledData[i][2], scheduledData[i][3]]);  //Not previewing so also send row number that way "Actual Tweet Time" can be set.
-          scheduledSheet.getRange("a" + scheduledData[i][3]).setValue("next-->");
+          scheduledSheet.getRange("c" + scheduledData[i][3]).setValue("next-->");
         } else if (!foundPreview) {                                 //Not previewing, tweet is in the future, and next marker not set 
-          scheduledSheet.getRange("a" + scheduledData[i][3]).setValue("next-->");
+          scheduledSheet.getRange("c" + scheduledData[i][3]).setValue("next-->");
           foundPreview = true;
           if (p.isAutoTiming == "true"                              //Auto updating timing is turned on
               && p.isScheduledPosting == "true") {                  //Currently in unattended posting mode.
@@ -289,7 +289,7 @@ function getScheduledText(count, preview) {
           }
         }
       } else if (!foundPreview) {                                   //Next tweet is after quota filled up.
-          scheduledSheet.getRange("a" + scheduledData[i][3]).setValue("next-->");
+          scheduledSheet.getRange("c" + scheduledData[i][3]).setValue("next-->");
           foundPreview = true;
           if (p.isAutoTiming == "true"                              //Auto updating timing is turned on
             && p.isScheduledPosting == "true") {                    //Currently in unattended posting mode.

--- a/Constructors.gs
+++ b/Constructors.gs
@@ -255,6 +255,7 @@ function getScheduledText(count, preview) {
     }
     if (scheduledData[i][3] < beforeNow             //Erase tweets that are in the past
         || scheduledData[i][2] > 0                  //Erase tweets that are already sent
+        || scheduledData[i][2] == "Duplicate (Race Condition?)"
         || scheduledData[i][2] == "Error") {        //Erase Error Tweets
       scheduledData[i][2] = "";
       scheduledData[i][3] = "";

--- a/README.md
+++ b/README.md
@@ -13,9 +13,10 @@ The `.gs` files in this repository are the underlying GAS code for the dev versi
 To use one of these spreadsheets, use "File -> Make a Copy..." to save it to your Google Drive.
 
 ### Current
-<a href="https://docs.google.com/spreadsheets/d/1QPyDXS3zsbHH1c4tzwrPcG-JV4YpvNBvAld2iEXeubs/edit?usp=sharing">SSBot v0.6.0</a>
+<a href="https://docs.google.com/spreadsheets/d/1v72qyc7ooDQgKeMpQUTiF1_3pFqKkUkIMpuYz3_ABd4/edit?usp=sharing">SSBot v0.6.5</a>
 
 ### Legacy
+<a href="https://docs.google.com/spreadsheets/d/1QPyDXS3zsbHH1c4tzwrPcG-JV4YpvNBvAld2iEXeubs/edit?usp=sharing">SSBot v0.6.0</a>
 
 <a href="https://docs.google.com/spreadsheets/d/1qfHjpevccgUXLwIgxlNKBejvcWeyqTP5Fj6vfBuBwuI/edit?usp=sharing">SSBot v0.5.2</a>
 


### PR DESCRIPTION
I've added some functionality, but I 'm not sure if this is a direction you are interested in your bot going or if you would rather me just keep this a separate fork. This pull request makes three changes

1. Word filter can be disabled. (I was having extremely high false positives with it.)
2. Scheduled Tweets can now retweet (with or without comments)
3. Scheduled Tweets can now be replies to tweets.

Technically it wouldn't be to difficult to add points 2 & 3 to the other options like Every, Markov, etc. but I personally didn't see much value there so I didn't.

My much longer term plans include allowing multiple twitter accounts to be managed from a single Google Sheet but that will be a pretty massive change, so I am also interested in knowing if you would like that functionally contributed back into this or not. As your input would probably change how I architect the implementation of that.